### PR TITLE
Fix for build errors when running setup on Windows

### DIFF
--- a/include/fcs16.h
+++ b/include/fcs16.h
@@ -1,1 +1,0 @@
-../yahdlc/C/fcs16.h

--- a/include/yahdlc.h
+++ b/include/yahdlc.h
@@ -1,1 +1,0 @@
-../yahdlc/C/yahdlc.h

--- a/lib/fcs16.c
+++ b/lib/fcs16.c
@@ -1,1 +1,0 @@
-../yahdlc/C/fcs16.c

--- a/lib/yahdlc.c
+++ b/lib/yahdlc.c
@@ -1,1 +1,0 @@
-../yahdlc/C/yahdlc.c

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ yahdlc = Extension(
     'yahdlc',
     sources = [
         DIR + '/src/python4yahdlc.c',
-        DIR + '/lib/fcs16.c',
-        DIR + '/lib/yahdlc.c'
+        DIR + '/yahdlc/C/fcs16.c',
+        DIR + '/yahdlc/C/yahdlc.c'
     ],
     include_dirs = [
-        DIR + '/include/'
+        DIR + '/yahdlc/C/'
     ],
 )
 


### PR DESCRIPTION
Hi SkypLabs,

I ran into some trouble installing the framework using setuptools on Windows:

`(xpider) D:\Development\xpider\python4yahdlc>python setup.py install
running install
running bdist_egg
running egg_info
creating python4yahdlc.egg-info
writing python4yahdlc.egg-info\PKG-INFO
writing dependency_links to python4yahdlc.egg-info\dependency_links.txt
writing top-level names to python4yahdlc.egg-info\top_level.txt
writing manifest file 'python4yahdlc.egg-info\SOURCES.txt'
reading manifest file 'python4yahdlc.egg-info\SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'python4yahdlc.egg-info\SOURCES.txt'
installing library code to build\bdist.win-amd64\egg
running install_lib
running build_ext
building 'yahdlc' extension
creating build
creating build\temp.win-amd64-3.7
creating build\temp.win-amd64-3.7\Release
creating build\temp.win-amd64-3.7\Release\Development
creating build\temp.win-amd64-3.7\Release\Development\xpider
creating build\temp.win-amd64-3.7\Release\Development\xpider\python4yahdlc
creating build\temp.win-amd64-3.7\Release\Development\xpider\python4yahdlc\src
creating build\temp.win-amd64-3.7\Release\Development\xpider\python4yahdlc\lib
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -ID:\Development\xpider\python4yahdlc/include/ -Id:\Tools\Anaconda3\envs\xpider\include -Id:\Tools\Anaconda3\envs\xpider\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.16299.0\cppwinrt" /TcD:\Development\xpider\python4yahdlc/src/python4yahdlc.c /Fobuild\temp.win-amd64-3.7\Release\Development\xpider\python4yahdlc/src/python4yahdlc.obj
python4yahdlc.c
D:\Development\xpider\python4yahdlc/include/yahdlc.h(1): error C2059: syntax error: '.'
D:\Development\xpider\python4yahdlc/src/python4yahdlc.c(23): error C2065: 'yahdlc_control_t': undeclared identifier
D:\Development\xpider\python4yahdlc/src/python4yahdlc.c(23): error C2146: syntax error: missing ';' before identifier 'control'
D:\Development\xpider\python4yahdlc/src/python4yahdlc.c(23): error C2065: 'control': undeclared identifier
D:\Development\xpider\python4yahdlc/src/python4yahdlc.c(34): warning C4013: 'yahdlc_get_data' undefined; assuming extern returning int
...
<snip>`

The issue that was occurring had to do with the reference files in include/lib. I updated setup.py to refer to the files out of the submodule and was able to build and install the lib successfully. I don't know if this approach is how you'd like to deal with the issue (there might be a neater solution you can think of, or there could be other impacts I'm not aware of). If not, feel free to reject this PR, all good.